### PR TITLE
Add pre-commit linters & Security Checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+# CodeQL: deep, language-aware SAST maintained by GitHub.
+name: codeql
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  schedule:
+    - cron: "25 1 * * 1"  # weekly, Mon 01:25 UTC
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:python"

--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,44 @@
+# pip-audit: checks Python deps against the Python advisory DB (OSV), complements Dependabot PRs.
+name: pip-audit
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+  schedule:
+    - cron: "15 3 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.10", "3.11", "3.12" ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install project
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          if [ -f pyproject.toml ]; then pip install .; fi
+
+      - name: Install pip-audit
+        run: pip install pip-audit
+
+      - name: Run pip-audit (SARIF)
+        run: pip-audit -r requirements.txt --format sarif --output pip-audit.sarif || true
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: pip-audit.sarif

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -1,0 +1,31 @@
+# Gitleaks: robust secrets scanning of diffs and history.
+name: secrets-scan
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+  schedule:
+    - cron: "35 2 * * *"   # daily
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # scan full history on scheduled runs
+
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: detect --source . --no-git=true --redact --report-format sarif --report-path gitleaks.sarif
+
+      - name: Upload SARIF to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,29 @@
+#Semgrep: fast, rule-driven SAST with excellent Python coverage, catches a different class of issues.
+
+name: semgrep
+
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+  schedule:
+    - cron: "5 2 * * 1"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: returntocorp/semgrep-action@v1
+        with:
+          config: >-
+            p/ci
+          generate-sarif: true
+          upload-sarif: true   # sends SARIF to GitHub Advanced Security "Code scanning"
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }} # optional if using Semgrep App

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,41 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+# Ruff linting and formatting
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.13.0
+  hooks:
+    # Run the linter.
+      - id: ruff-check
+        files: ^(hts_synth|tests)/.*\.py$
+        always_run: true
+    # Run the formatter.
+    #   - id: ruff-format
+    #     files: ^(hts_synth|tests)/.*\.py$
+    #     always_run: true
+
+# BasedPyright static type checking
+- repo: https://github.com/DetachHead/basedpyright-pre-commit-mirror
+  rev: v1.13.0
+  hooks:
+    - id: basedpyright
+
+
+# Local pytest hook using .venv Python
+- repo: local
+  hooks:
+    - id: pytest
+      name: pytest
+      entry: .venv/bin/python -m pytest
+      language: system
+      types: [python]
+      always_run: true

--- a/README.md
+++ b/README.md
@@ -16,10 +16,22 @@ From the repo's base directory
 
 ```sh
 pyenv install 3.12
-python -m venv .venv
+python3 -m venv .venv
 source ./.venv/bin/activate
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
+```
+
+## Contributing
+
+The followng checks are automatically run by pre-commit.
+If this is the first time you're commiting to this repo, ensure your pre-commit is configured.
+
+Note: you will need to have an SSH public keyadded to your GitHub profile.
+
+```bash
+source ./.venv/bin/activate
+pre-commit
 ```
 
 ### Linting and Typing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Faker>=18.0.0
 pytest>=8.4.2
-numpy>=2.3
+numpy>=2.0.0
 pysam ~= 0.23.3


### PR DESCRIPTION
* pre-commit that auto runs linters and pytest suite
* Enabled [Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide) 
* CodeQL: deep, language-aware SAST maintained by GitHub.
* Semgrep: fast, rule-driven SAST with excellent Python coverage, catches a different class of issues.
* Gitleaks: robust secrets scanning of diffs and history.
* pip-audit: checks Python deps against the Python advisory DB (OSV), complements Dependabot PRs.

N.B: ruff formatter is disabled until someone who knows the code can review its results